### PR TITLE
Removes base url from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ title: jekyll-theme-hackcss
 description: > # this means to ignore newlines until "baseurl:"
   A minimalistic theme for Jekyll, based on hack.css
 repository: https://github.com/wemake-services/jekyll-theme-hackcss
-baseurl: /jekyll-theme-hackcss  # the subpath of your site, e.g. /blog
 url: https://wemake-services.github.io  # the base hostname & protocol for your site
 
 # Build settings


### PR DESCRIPTION
This isn't needed to run the site locally and it's not compatible with gh pages.